### PR TITLE
Remove README.md packaging configuration from NuGet props

### DIFF
--- a/build/global.props
+++ b/build/global.props
@@ -7,6 +7,8 @@
     <PropertyGroup>
         <!-- Use latest C# language features -->
         <LangVersion>latest</LangVersion>
+        <!-- Enable implicit global usings for System, System.Collections.Generic, etc. -->
+        <ImplicitUsings>enable</ImplicitUsings>
         <!-- Enforce nullable reference types across libraries -->
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/build/nuget-package.props
+++ b/build/nuget-package.props
@@ -37,7 +37,6 @@
         <PackageProjectUrl>https://github.com/veggerby/shardis</PackageProjectUrl>
         <Company>Shardis Project</Company>
         <PackageIcon Condition="Exists('$(DocsFolder)\icon.png')">icon.png</PackageIcon>
-        <PackageReadmeFile Condition="Exists('README.md')">README.md</PackageReadmeFile>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <IncludeSymbols>true</IncludeSymbols>
         <EnablePackageValidation>true</EnablePackageValidation>
@@ -46,7 +45,6 @@
     <!-- Additional Files -->
     <ItemGroup>
         <None Include="$(DocsFolder)\icon.png" Pack="true" PackagePath="/" Condition="Exists('$(DocsFolder)\icon.png')" />
-        <None Include="README.md" Pack="true" PackagePath="/" Condition="Exists('README.md')" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <!-- Import parent Directory.Build.props (from repo root) -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <!-- Import NuGet packaging configuration -->
+  <Import Project="$(BuildFolder)nuget-package.props" />
+
+</Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,7 +1,5 @@
 <Project>
 
-  <Import Project="$(BuildFolder)\nuget-package.props" />
-
   <PropertyGroup>
     <PackageReleaseNotesFile Condition="'$(PackageReleaseNotesFile)' == ''">RELEASE_NOTES.md</PackageReleaseNotesFile>
   </PropertyGroup>

--- a/src/Shardis.DependencyInjection/Shardis.DependencyInjection.csproj
+++ b/src/Shardis.DependencyInjection/Shardis.DependencyInjection.csproj
@@ -1,24 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
+  <!-- Package Metadata -->
   <PropertyGroup>
     <PackageId>Shardis.DependencyInjection</PackageId>
-    <Version>0.1.0</Version>
     <Description>Fluent shard registration &amp; per-shard resource factories for Shardis using Microsoft.Extensions.DependencyInjection.</Description>
-    <PackageTags>shardis;sharding;dependency-injection;factory;partitioning</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>Initial release. Full notes: https://github.com/veggerby/shardis/blob/main/CHANGELOG.md#010---2025-08-25</PackageReleaseNotes>
+    <PackageTags>shardis sharding dependency-injection factory partitioning</PackageTags>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="icon.png" Pack="true" PackagePath="" Condition="Exists('icon.png')" />
-    <None Include="README.md" Pack="true" PackagePath="" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="../Shardis/Shardis.csproj" />

--- a/src/Shardis.Logging.Console/Shardis.Logging.Console.csproj
+++ b/src/Shardis.Logging.Console/Shardis.Logging.Console.csproj
@@ -1,21 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- Package Metadata -->
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>Shardis.Logging.Console</PackageId>
     <Description>Lightweight console logger implementation for the Shardis logging abstraction. Intended for samples and local diagnostics.</Description>
-    <PackageTags>shardis;sharding;logging;console</PackageTags>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>shardis sharding logging console</PackageTags>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="icon.png" Pack="true" PackagePath="" Condition="Exists('icon.png')" />
-    <None Include="README.md" Pack="true" PackagePath="" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="../Shardis/Shardis.csproj" />

--- a/src/Shardis.Logging.Microsoft/Shardis.Logging.Microsoft.csproj
+++ b/src/Shardis.Logging.Microsoft/Shardis.Logging.Microsoft.csproj
@@ -1,25 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- Package Metadata -->
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>Shardis.Logging.Microsoft</PackageId>
     <Description>Adapter bridging the Shardis logging abstraction to Microsoft.Extensions.Logging infrastructure.</Description>
-    <PackageTags>shardis;sharding;logging;adapter;Microsoft.Extensions.Logging</PackageTags>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>shardis sharding logging adapter Microsoft.Extensions.Logging</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="icon.png" Pack="true" PackagePath="" Condition="Exists('icon.png')" />
-    <None Include="README.md" Pack="true" PackagePath="" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="../Shardis/Shardis.csproj" />
- </ItemGroup>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />

--- a/src/Shardis.Marten/Shardis.Marten.csproj
+++ b/src/Shardis.Marten/Shardis.Marten.csproj
@@ -1,24 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
+  <!-- Package Metadata -->
   <PropertyGroup>
     <PackageId>Shardis.Marten</PackageId>
-    <Version>0.1.0</Version>
     <Description>Marten integration for Shardis: per-shard sessions and query execution adapter.</Description>
-    <PackageTags>shardis;sharding;marten;document-db;consistent-hashing;partitioning;dotnet</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>Initial release. Full notes: https://github.com/veggerby/shardis/blob/main/CHANGELOG.md#010---2025-08-25</PackageReleaseNotes>
+    <PackageTags>shardis sharding marten document-db consistent-hashing partitioning dotnet</PackageTags>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="icon.png" Pack="true" PackagePath="" Condition="Exists('icon.png')" />
-    <None Include="README.md" Pack="true" PackagePath="" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Marten" />

--- a/src/Shardis.Migration.EntityFrameworkCore/Shardis.Migration.EntityFrameworkCore.csproj
+++ b/src/Shardis.Migration.EntityFrameworkCore/Shardis.Migration.EntityFrameworkCore.csproj
@@ -1,20 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- Package Metadata -->
   <PropertyGroup>
     <TargetFrameworks>net10.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <PackageId>Shardis.Migration.EntityFrameworkCore</PackageId>
-    <Version>0.1.0</Version>
     <Description>Entity Framework Core migration provider for Shardis (data mover + verification strategies).</Description>
-    <PackageTags>shardis;sharding;EntityFrameworkCore;migration;data-mover</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>shardis sharding EntityFrameworkCore migration data-mover</PackageTags>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="icon.png" Pack="true" PackagePath="" Condition="Exists('icon.png')" />
-    <None Include="README.md" Pack="true" PackagePath="" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" />

--- a/src/Shardis.Migration.Marten/Shardis.Migration.Marten.csproj
+++ b/src/Shardis.Migration.Marten/Shardis.Migration.Marten.csproj
@@ -1,20 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- Package Metadata -->
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <PackageId>Shardis.Migration.Marten</PackageId>
-    <Version>0.1.0</Version>
     <Description>Marten migration provider for Shardis (document data mover + checksum verification).</Description>
-    <PackageTags>shardis;sharding;marten;migration;data-mover;document</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>shardis sharding marten migration data-mover document</PackageTags>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="icon.png" Pack="true" PackagePath="" Condition="Exists('icon.png')" />
-    <None Include="README.md" Pack="true" PackagePath="" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Marten" />

--- a/src/Shardis.Migration.Sql/Shardis.Migration.Sql.csproj
+++ b/src/Shardis.Migration.Sql/Shardis.Migration.Sql.csproj
@@ -1,19 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- Package Metadata -->
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>Shardis.Migration.Sql</PackageId>
     <Description>Durable SQL-backed components (checkpoint store, shard map + history) for Shardis migration.</Description>
-    <PackageTags>shardis;sharding;migration;checkpoint;sql</PackageTags>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <PackageTags>shardis sharding migration checkpoint sql</PackageTags>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="icon.png" Pack="true" PackagePath="" Condition="Exists('icon.png')" />
-    <None Include="README.md" Pack="true" PackagePath="" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="../Shardis.Migration/Shardis.Migration.csproj" />

--- a/src/Shardis.Migration/Shardis.Migration.csproj
+++ b/src/Shardis.Migration/Shardis.Migration.csproj
@@ -1,24 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
+  <!-- Package Metadata -->
   <PropertyGroup>
     <PackageId>Shardis.Migration</PackageId>
-    <Version>0.1.0</Version>
     <Description>Shardis key migration execution primitives (planner, executor, metrics hooks, in-memory implementations).</Description>
-    <PackageTags>shardis;sharding;migration;data-migration;consistent-hashing;partitioning</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>Initial release. Full notes: https://github.com/veggerby/shardis/blob/main/CHANGELOG.md#010---2025-08-25</PackageReleaseNotes>
+    <PackageTags>shardis sharding migration data-migration consistent-hashing partitioning</PackageTags>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="icon.png" Pack="true" PackagePath="" Condition="Exists('icon.png')" />
-    <None Include="README.md" Pack="true" PackagePath="" />
-  </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Shardis.Migration.Tests" />
@@ -27,7 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../Shardis/Shardis.csproj" />
- </ItemGroup>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />

--- a/src/Shardis.Query.EntityFrameworkCore/Shardis.Query.EntityFrameworkCore.csproj
+++ b/src/Shardis.Query.EntityFrameworkCore/Shardis.Query.EntityFrameworkCore.csproj
@@ -1,24 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- Package Metadata -->
   <PropertyGroup>
     <TargetFrameworks>net10.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <PackageId>Shardis.Query.EntityFrameworkCore</PackageId>
-    <Version>0.1.0</Version>
     <Description>Entity Framework Core query executor for Shardis (Where/Select pushdown, unordered streaming).</Description>
-    <PackageTags>shardis;sharding;EntityFrameworkCore;query;linq</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>Initial release. Full notes: https://github.com/veggerby/shardis/blob/main/CHANGELOG.md#010---2025-08-25</PackageReleaseNotes>
+    <PackageTags>shardis sharding EntityFrameworkCore query linq</PackageTags>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="icon.png" Pack="true" PackagePath="" Condition="Exists('icon.png')" />
-    <None Include="README.md" Pack="true" PackagePath="" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" />

--- a/src/Shardis.Query.InMemory/Shardis.Query.InMemory.csproj
+++ b/src/Shardis.Query.InMemory/Shardis.Query.InMemory.csproj
@@ -1,32 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
+  <!-- Package Metadata -->
   <PropertyGroup>
     <PackageId>Shardis.Query.InMemory</PackageId>
-    <Version>0.1.0</Version>
     <Description>In-memory query executor for Shardis (testing, prototyping).</Description>
-    <PackageTags>shardis;sharding;in-memory;query;testing</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>Initial release. Full notes: https://github.com/veggerby/shardis/blob/main/CHANGELOG.md#010---2025-08-25</PackageReleaseNotes>
+    <PackageTags>shardis sharding in-memory query testing</PackageTags>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="icon.png" Pack="true" PackagePath="" Condition="Exists('icon.png')" />
-    <None Include="README.md" Pack="true" PackagePath="" />
-  </ItemGroup>
-
-
-  <ItemGroup>
-    <ProjectReference Include="../Shardis.Query/Shardis.Query.csproj" />
-  </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Shardis.Query.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Shardis.Query/Shardis.Query.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Shardis.Query.Marten/Shardis.Query.Marten.csproj
+++ b/src/Shardis.Query.Marten/Shardis.Query.Marten.csproj
@@ -1,24 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
+  <!-- Package Metadata -->
   <PropertyGroup>
     <PackageId>Shardis.Query.Marten</PackageId>
-    <Version>0.1.0</Version>
     <Description>Marten query execution components for Shardis fluent query MVP.</Description>
-    <PackageTags>shardis;sharding;marten;query;linq</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>Initial release. Full notes: https://github.com/veggerby/shardis/blob/main/CHANGELOG.md#010---2025-08-25</PackageReleaseNotes>
+    <PackageTags>shardis sharding marten query linq</PackageTags>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="icon.png" Pack="true" PackagePath="" Condition="Exists('icon.png')" />
-    <None Include="README.md" Pack="true" PackagePath="" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Marten" />

--- a/src/Shardis.Query/Shardis.Query.csproj
+++ b/src/Shardis.Query/Shardis.Query.csproj
@@ -1,24 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
+  <!-- Package Metadata -->
   <PropertyGroup>
     <PackageId>Shardis.Query</PackageId>
-    <Version>0.1.0</Version>
     <Description>Core query primitives (merge enumerators, LINQ MVP scaffolding) used by Shardis provider packages.</Description>
-    <PackageTags>shardis;sharding;query;linq;merge;partitioning</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>Initial release. Full notes: https://github.com/veggerby/shardis/blob/main/CHANGELOG.md#010---2025-08-25</PackageReleaseNotes>
+    <PackageTags>shardis sharding query linq merge partitioning</PackageTags>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="icon.png" Pack="true" PackagePath="" Condition="Exists('icon.png')" />
-    <None Include="README.md" Pack="true" PackagePath="" />
-  </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Shardis.Query.Tests" />

--- a/src/Shardis.Redis/Shardis.Redis.csproj
+++ b/src/Shardis.Redis/Shardis.Redis.csproj
@@ -1,24 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
+  <!-- Package Metadata -->
   <PropertyGroup>
     <PackageId>Shardis.Redis</PackageId>
-    <Version>0.1.0</Version>
     <Description>Redis-backed shard map store for Shardis (atomic CAS &amp; TryGetOrAdd) enabling deterministic key to shard assignments.</Description>
-    <PackageTags>shardis;sharding;redis;consistent-hashing;partitioning;dotnet</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>Initial release. Full notes: https://github.com/veggerby/shardis/blob/main/CHANGELOG.md#010---2025-08-25</PackageReleaseNotes>
+    <PackageTags>shardis sharding redis consistent-hashing partitioning dotnet</PackageTags>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="icon.png" Pack="true" PackagePath="" Condition="Exists('icon.png')" />
-    <None Include="README.md" Pack="true" PackagePath="" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="StackExchange.Redis" />

--- a/src/Shardis/Shardis.csproj
+++ b/src/Shardis/Shardis.csproj
@@ -1,24 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
+  <!-- Package Metadata -->
   <PropertyGroup>
     <PackageId>Shardis</PackageId>
-    <Version>0.1.0</Version>
     <Description>Deterministic sharding primitives for .NET: consistent hash routing, modulo router, broadcasting, metrics hooks, migration scaffold.</Description>
-    <PackageTags>shardis;sharding;consistent-hashing;partitioning;distributed-systems;dotnet;router</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>Initial release. Full notes: https://github.com/veggerby/shardis/blob/main/CHANGELOG.md#010---2025-08-25</PackageReleaseNotes>
+    <PackageTags>shardis sharding consistent-hashing partitioning distributed-systems dotnet router</PackageTags>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="icon.png" Pack="true" PackagePath="" Condition="Exists('icon.png')" />
-    <None Include="README.md" Pack="true" PackagePath="" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />


### PR DESCRIPTION
Eliminate the README.md references from the NuGet packaging configuration to streamline the package creation process.